### PR TITLE
Refactor ScrollSpy for better implementation

### DIFF
--- a/src/app/(app)/components/Projects/ScrollSpy.tsx
+++ b/src/app/(app)/components/Projects/ScrollSpy.tsx
@@ -1,10 +1,10 @@
 "use client";
 import React, { useContext, useEffect, useState } from "react";
 import Text from "@/components/Text";
-import { cn } from "@/lib/utils";
 import { motion } from "framer-motion";
 import * as Accordion from "@radix-ui/react-accordion";
 import InViewContext from "@/contexts/InViewContext";
+import ScrollSpyTrackline from "./ScrollSpyTrackline";
 
 export type ScrollSpyType = {
   title: string;
@@ -27,7 +27,7 @@ const AccordionRoot = ({ sections }: { sections: ScrollSpyType[] }) => {
   const { inView } = useContext(InViewContext);
   return (
     <Accordion.Root
-      className="flex flex-col"
+      className="flex flex-col gap-8px"
       type="single"
       value={inView.section as string}
       collapsible
@@ -84,20 +84,6 @@ const ScrollSpyItem = ({
     scrollToViewHandler(id);
   };
 
-  // These getPathStyle methods styles the path according to the item's place
-  // on the array, if the item is index 3, it styles itself and the indexes less than 3
-  const getPathHoverStyle = (i: number, vertical?: boolean) => {
-    return hoveredItemIndex !== undefined && vertical
-      ? cn(hoveredItemIndex >= i && "hovered")
-      : cn(hoveredItemIndex == i && "hovered");
-  };
-
-  const getPathActiveStyle = (i: number, vertical?: boolean) => {
-    return activeItemIndex !== undefined && vertical
-      ? cn(activeItemIndex >= i && "active")
-      : cn(activeItemIndex == i && "active");
-  };
-
   const scrollToViewHandler = (id: string) => {
     const element = document.getElementById(id);
     element?.scrollIntoView({ behavior: "smooth" });
@@ -106,9 +92,9 @@ const ScrollSpyItem = ({
   return (
     <Accordion.Item
       value={id}
-      className="w-full cursor-pointer flex flex-col gap-4px transition-all ease-in-out"
+      className="w-full cursor-pointer flex flex-col gap-8px transition-all ease-in-out"
     >
-      <Accordion.Header>
+      <Accordion.Header className="inline-flex">
         <Accordion.Trigger
           className="inline-flex"
           onClick={() => scrollToViewHandler(id)}
@@ -127,6 +113,7 @@ const ScrollSpyItem = ({
 
       <Accordion.Content
         data-state="open"
+        id={`spy-items-container-${id}`}
         className="spy-items-container"
         asChild
       >
@@ -134,20 +121,18 @@ const ScrollSpyItem = ({
           {blocks.map(({ lead, htmlID }, i) => (
             <div
               key={i}
+              id={`scrollspy-item-${htmlID}`}
               className="group spy-item last:mb-8px"
               onMouseEnter={() => onMouseEnterHandler(i)}
               onMouseLeave={() => onMouseLeaveHandler()}
               onClick={() => onClickHandler(i, htmlID)}
             >
-              <div
-                className={`trackline trackline-v 
-                ${getPathHoverStyle(i, true)}
-                ${getPathActiveStyle(i, true)}`}
-              />
-              <div
-                className={`trackline trackline-h 
-                ${getPathHoverStyle(i)} 
-                ${getPathActiveStyle(i)}`}
+              <ScrollSpyTrackline
+                activeItemIndex={activeItemIndex}
+                hoveredItemIndex={hoveredItemIndex}
+                index={i}
+                parentID={`spy-items-container-${id}`}
+                childID={`scrollspy-item-${htmlID}`}
               />
               <Text
                 className={`transition-color duration-300 ease-in-out group-hover:text text-wrap ${

--- a/src/app/(app)/components/Projects/ScrollSpyTrackline.tsx
+++ b/src/app/(app)/components/Projects/ScrollSpyTrackline.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { useEffect, useState } from "react";
+
+const ScrollSpyTrackline = ({
+  hoveredItemIndex,
+  activeItemIndex,
+  index,
+  parentID,
+  childID,
+}: {
+  hoveredItemIndex: number | undefined;
+  activeItemIndex: number | undefined;
+  index: number;
+  parentID: string;
+  childID: string;
+}) => {
+  const [tracklineHeight, setTracklineHeight] = useState(0);
+  const [hoverStyle, setHoverStyle] = useState<string>("");
+  const [activeStyle, setActiveStyle] = useState<string>("");
+
+  const getTracklineHeight = (parentID: string, childID: string) => {
+    const parent = document.getElementById(parentID);
+    const child = document.getElementById(childID);
+
+    if (parent && child) {
+      const parentRect = parent?.getBoundingClientRect();
+      const childRect = child?.getBoundingClientRect();
+
+      // Calculate the distance
+      const distance =
+        childRect.bottom - parentRect.top - childRect.height * 0.5;
+      return distance;
+    } else return 0;
+  };
+
+  const getPathHoverStyle = (i: number) => {
+    if (hoveredItemIndex !== undefined) {
+      return cn(hoveredItemIndex == i && "hovered");
+    } else return "";
+  };
+
+  const getPathActiveStyle = (i: number) => {
+    if (activeItemIndex !== undefined) {
+      return cn(activeItemIndex == i && "active");
+    } else return "";
+  };
+
+  useEffect(() => {
+    const height = getTracklineHeight(parentID, childID);
+    setTracklineHeight(height);
+  }, []);
+
+  useEffect(() => {
+    const hoverStyle = getPathHoverStyle(index);
+    const activeStyle = getPathActiveStyle(index);
+
+    setHoverStyle(hoverStyle);
+    setActiveStyle(activeStyle);
+  }, [index]);
+
+  return (
+    <div
+      className={cn(
+        "trackline",
+        `${getPathHoverStyle(index)}`,
+        `${getPathActiveStyle(index)}`
+      )}
+      style={{
+        height: tracklineHeight,
+      }}
+    />
+  );
+};
+
+export default ScrollSpyTrackline;

--- a/src/app/(app)/projects/[project]/loading.tsx
+++ b/src/app/(app)/projects/[project]/loading.tsx
@@ -1,0 +1,5 @@
+const Loading = () => {
+  return <div>Loading...</div>;
+};
+
+export default Loading;

--- a/src/app/(app)/styles/globals.css
+++ b/src/app/(app)/styles/globals.css
@@ -161,7 +161,7 @@
   .spy-items-container {
     position: relative;
     overflow: hidden;
-    padding-left: 4px;
+    padding-left: 2px;
     padding-top: 2px;
   }
 
@@ -170,7 +170,16 @@
   }
 
   .spy-item {
+    cursor: pointer;
+    width: fit-content;
+    position: relative;
+    display: flex;
+    padding-left: 18px;
     margin-top: 8px;
+
+    &:hover {
+      opacity: 100%;
+    }
   }
 
   .spy-items-container[data-state="open"] {
@@ -199,24 +208,10 @@
     }
   }
 
-  .spy-item {
-    cursor: pointer;
-    width: fit-content;
-    position: relative;
-    display: flex;
-    gap: 4px;
-    padding-left: 16px;
-
-    &:hover {
-      opacity: 100%;
-    }
-  }
-
   .trackline.hovered {
     border-color: hsl(var(--trackline-hover));
   }
 
-  .trackline.path.active,
   .trackline.active {
     border-color: hsl(var(--trackline-active));
   }
@@ -224,31 +219,15 @@
   .trackline {
     transition: border-color 300ms ease-in-out;
     mix-blend-mode: lighten;
-  }
 
-  .trackline-v {
     position: absolute;
-    left: 0;
-    top: -24px;
-    bottom: 16px;
-    border-left: 1px;
-    border-style: solid;
-    border-color: hsl(var(--trackline));
-    width: 1px;
-    height: 25px;
-  }
-
-  .trackline-h {
-    position: absolute;
+    bottom: calc(100% - 8px);
     left: 0px;
-    display: inline-block;
-    border-width: 0px 0px 1px 1px;
-    border-style: solid;
-    border-color: hsl(var(--trackline));
-    border-radius: 0 0 0 8px;
     width: 12px;
-    height: 8px;
-    margin-bottom: 8px;
+    border: 1px solid hsl(var(--trackline));
+    border-right: 0px;
+    border-top: 0px;
+    border-radius: 0px 0px 0px 14px;
   }
 
   .light-streak {


### PR DESCRIPTION
The trackline-h trackline-v implementation does not look visually good. I refactored to use only one trackline that automatically measures its height by getting child bottom rect and parent top rect and subtracting half of the child height